### PR TITLE
refactor: remove unused imports to clean up code

### DIFF
--- a/src/shared/components/Modal.tsx
+++ b/src/shared/components/Modal.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useRef } from 'react';
-import { motion, AnimatePresence, TargetAndTransition, VariantLabels, AnimationControls } from 'framer-motion';
+import { motion, AnimatePresence, TargetAndTransition, VariantLabels } from 'framer-motion';
 
 interface ModalProps {
     isOpen: boolean;

--- a/src/users/components/private/FormNatural.tsx
+++ b/src/users/components/private/FormNatural.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { FormLayout } from "../shared/FormLayout";
 import { FormInput } from "../shared/FormInput";
 import { CreationButton } from "../shared/CreationButton";
 import { UsersService } from "@/users/service/usersService";


### PR DESCRIPTION
Remove unused imports from Modal.tsx and FormNatural.tsx to improve code readability and maintainability. This change eliminates unnecessary dependencies and reduces potential confusion for developers.