### PR TITLE
feat: add entityId to user object for entity-specific requests

### DIFF
--- a/src/auth/api/authApi.ts
+++ b/src/auth/api/authApi.ts
@@ -11,6 +11,7 @@ interface LoginResponse {
     token: string;
     user: {
       id: number;
+      entityId: number;
       username: string;
       email: string;
       roles: string[];

--- a/src/auth/context/UserContext.tsx
+++ b/src/auth/context/UserContext.tsx
@@ -4,6 +4,7 @@ import { AuthService } from "../services/authService";
 
 interface User {
   id: number;
+  entityId: number;
   username: string;
   email: string;
   roles: string[];

--- a/src/auth/services/authService.ts
+++ b/src/auth/services/authService.ts
@@ -5,6 +5,7 @@ interface LoginResponse {
   token: string;
   user: {
     id: number;
+    entityId: number;
     username: string;
     email: string;
     roles: string[];

--- a/src/requests/pages/RequestsListPage.tsx
+++ b/src/requests/pages/RequestsListPage.tsx
@@ -13,7 +13,7 @@ export function RequestsListPage() {
     const [requests, setRequests] = useState<Request[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-
+    
     const isAdmin = useHasRole(ROLES.ADMIN);
 
     useEffect(() => {
@@ -21,7 +21,7 @@ export function RequestsListPage() {
             try {
                 const data = await (isAdmin 
                     ? requestsService.getAllPeople()
-                    : requestsService.getAllPeopleByEntityId(2)
+                    : requestsService.getAllPeopleByEntityId(user?.entityId as number)
                 );
                 setRequests(data.people);
                 setLoading(false);


### PR DESCRIPTION
The entityId field was added to the user object across multiple files to support entity-specific data fetching in the RequestsListPage. This ensures that non-admin users can only access data relevant to their entity.